### PR TITLE
Bugfix: correct timeout for search

### DIFF
--- a/PandaDealer-sat-1.def
+++ b/PandaDealer-sat-1.def
@@ -75,8 +75,8 @@ From: ubuntu:22.04
 		exit 102
 	fi
 	end_time=$(date +%s)
-    time_difference=$((end_time - start_time))
-    new_timelimit=$((1770 - time_difference))
+	time_difference=$((end_time - start_time))
+	new_timelimit=$((1770 - time_difference))
 
 	/planner/pandaPIengine --gValue=none --suboptimal --pruneDeadEnds --optSol --timelimit=$new_timelimit --heuristic="rc2(add)" "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
 

--- a/PandaDealer-sat-1.def
+++ b/PandaDealer-sat-1.def
@@ -61,6 +61,7 @@ From: ubuntu:22.04
 	## PLANFILE=$3
 
 	## run your planner here
+	start_time=$(date +%s)
 	/planner/pandaPIparser $1 $2 temp.parsed
 	if [ ! -f temp.parsed ]; then
 		echo "Parsing failed."
@@ -73,8 +74,11 @@ From: ubuntu:22.04
 		echo "Grounding failed."
 		exit 102
 	fi
+	end_time=$(date +%s)
+    time_difference=$((end_time - start_time))
+    new_timelimit=$((1770 - time_difference))
 
-	/planner/pandaPIengine --gValue=none --suboptimal --pruneDeadEnds --optSol --timelimit=1770 --heuristic="rc2(add)" "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
+	/planner/pandaPIengine --gValue=none --suboptimal --pruneDeadEnds --optSol --timelimit=$new_timelimit --heuristic="rc2(add)" "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
 
 	/planner/pandaPIparser -c panda.log $3
 

--- a/PandaDealer-sat-2.def
+++ b/PandaDealer-sat-2.def
@@ -75,8 +75,8 @@ From: ubuntu:22.04
 		exit 102
 	fi
 	end_time=$(date +%s)
-    time_difference=$((end_time - start_time))
-    new_timelimit=$((1780 - time_difference))
+	time_difference=$((end_time - start_time))
+	new_timelimit=$((1780 - time_difference))
 
 	/planner/pandaPIengine --astarweight=2 --suboptimal --pruneDeadEnds --heuristic="rc2(ff)" --optSol --timelimit=$new_timelimit "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
 

--- a/PandaDealer-sat-2.def
+++ b/PandaDealer-sat-2.def
@@ -61,6 +61,7 @@ From: ubuntu:22.04
 	## PLANFILE=$3
 
 	## run your planner here
+	start_time=$(date +%s)
 	/planner/pandaPIparser $1 $2 temp.parsed
 	if [ ! -f temp.parsed ]; then
 		echo "Parsing failed."
@@ -73,8 +74,11 @@ From: ubuntu:22.04
 		echo "Grounding failed."
 		exit 102
 	fi
+	end_time=$(date +%s)
+    time_difference=$((end_time - start_time))
+    new_timelimit=$((1780 - time_difference))
 
-	/planner/pandaPIengine --astarweight=2 --suboptimal --pruneDeadEnds --heuristic="rc2(ff)" --optSol --timelimit=1780 "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
+	/planner/pandaPIengine --astarweight=2 --suboptimal --pruneDeadEnds --heuristic="rc2(ff)" --optSol --timelimit=$new_timelimit "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
 
 	/planner/pandaPIparser -c panda.log $3
 


### PR DESCRIPTION
We would like to get the permission for pushing a bugfix. The bug is that we didn't set the timeout for running our planners properly in the satisficing track. More specifically, we intend to restrict our planners to run within 1780 (and 1770, resp.) seconds so that we could have a 20-seconds buffer to write down the plan we found, i.e., that 1780 seconds should include the time for parsing, grounding, preprocessing, and searching. However, in our actual implementation, we incorrectly allocated the whole 1780 seconds to searching. This is indeed a severe bug for our planner because our planner does not stop when the first solution is found. Our planner will use the rest of the time limit we set to try to find a better plan. Therefore, in our scenario, since we did not take into account the time for preprocessing and assign all 1780 seconds to searching, it might result in the situation that we only have a few seconds to write down the solution we found, and for a very long solution, these few seconds might not be enough for writing it down. Consequently, we want to adjust the time limit so that these 1780 seconds include the time for all preprocessing steps. 