### PR TITLE
Bugfix sat-lama config

### DIFF
--- a/PandaDealer-sat-lama.def
+++ b/PandaDealer-sat-lama.def
@@ -40,7 +40,7 @@ From: ubuntu:22.04
 	mv pandaPIgrounder ..
 	cd ..
 
-	cd 02-planner/src
+	cd 03-planner/src
 	mkdir bin
 	cd bin
 	cmake ..

--- a/PandaDealer-sat-lama.def
+++ b/PandaDealer-sat-lama.def
@@ -40,7 +40,7 @@ From: ubuntu:22.04
 	mv pandaPIgrounder ..
 	cd ..
 
-	cd 03-planner/src
+	cd 03-lama-planner/src
 	mkdir bin
 	cd bin
 	cmake ..

--- a/PandaDealer-sat-lama.def
+++ b/PandaDealer-sat-lama.def
@@ -74,7 +74,7 @@ From: ubuntu:22.04
 		exit 102
 	fi
 
-	/planner/pandaPIengine --heuristic="rc2(lmc;cost)" --gValue=action --pruneDeadEnds "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
+	/planner/pandaPIengine "--heuristic=lama(lazy=false;ha=false;lm=lmc;useLMOrd=false;h=add;search=gbfs)" "$(basename "$1" .hddl)-$(basename "$2" .hddl).psas" >> panda.log
 
 	/planner/pandaPIparser -c panda.log $3
 


### PR DESCRIPTION
Bugfix of PandaDealer-sat-lama.def: We intended to participate in the satisficing track with PandaDealer-lama using the same configuration as in the agile track. Accidentally, we copied a configuration from the optimal track (which makes absolutely no sense) - it was simply a pure copy and paste error.